### PR TITLE
Added /usr/include to compiler options for linux

### DIFF
--- a/kotlin-native/samples/fullstack/utils/src/main/c_interop/freetype.def
+++ b/kotlin-native/samples/fullstack/utils/src/main/c_interop/freetype.def
@@ -2,6 +2,6 @@ package = freetype2
 headers = freetype.h sys/stat.h
 compilerOpts = -DFT_FREETYPE_H
 compilerOpts.osx = -I/opt/local/include/freetype2/freetype -I/opt/local/include/freetype2
-compilerOpts.linux = -I/usr/include/freetype2/freetype -I/usr/include/freetype2
+compilerOpts.linux = -I/usr/include/freetype2/freetype -I/usr/include/freetype2 -I/usr/include
 linkerOpts.osx = -L/opt/local/lib -lfreetype
 linkerOpts.linux = -L/usr/lib -L/usr/lib/x86_64-linux-gnu -lfreetype


### PR DESCRIPTION
It looks like we have to include `/usr/include` since when resolving `ftheader.h` (`/usr/include/freetype2/freetype/config/ftheader.h`) it tries to include `#  include <x86_64-linux-gnu/freetype2/freetype/config/ftheader.h>` which is relative to `/usr/include`. 

There is actually another thing. Why do we include `/usr/include/freetype2/freetype` and `/usr/include/freetype2` here and in `CMakeLists.txt` as well: `COMPILER_OPTS "-I ${FREETYPE_INCLUDE_DIR} -I ${FREETYPE_INCLUDE_DIR}/.."`? I believe `FREETYPE_INCLUDE_DIR` is resolved as `/usr/include/freetype2`.